### PR TITLE
Added example of a DNS challenge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,12 @@ Feel free to open tickets or merge requests if you think something is missing.
 
 #### Auto-SSL with Let's Encrypt
 
+##### Auto-SSL with DNS-Challenge
+- [Example code](ssl/auto-ssl/dns-challenge/docker-compose.yml)
+
+##### Auto-SSL with DNS-Challenge and wildcard certificate
+- [Example code](ssl/auto-ssl/dns-challenge-wildcard/docker-compose.yml)
+
 ##### Auto-SSL with HTTP-Challenge (NOT WORKING LOCALLY!)
 - [Example code](ssl/auto-ssl/http-challenge/docker-compose.yml)
 

--- a/ssl/auto-ssl/dns-challenge-wildcard/docker-compose.yml
+++ b/ssl/auto-ssl/dns-challenge-wildcard/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - "--entrypoints.websecure.http.tls.certResolver=letsencrypt"
       # Creates a wildcard certificate, messages like 404 pages are returned encrypted by Treafik.
       - "--entrypoints.websecure.http.tls.domains[0].main=example.com"
-      - "--entrypoints.websecure.http.tls.domains[0].sans=*.example.com" #
+      - "--entrypoints.websecure.http.tls.domains[0].sans=*.example.com"
     ports:
       - "80:80"
       - "443:443"

--- a/ssl/auto-ssl/dns-challenge-wildcard/docker-compose.yml
+++ b/ssl/auto-ssl/dns-challenge-wildcard/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3'
+
+services:
+  traefik:
+    image: traefik:v2.2
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./letsencrypt/:/letsencrypt/
+    command:
+      - "--providers.docker"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.webwecure.address=:443"
+      - "--certificatesresolvers.default.acme.dnschallenge=true"
+      # See here for your dnschallenge provider: https://go-acme.github.io/lego/dns/
+      - "--certificatesresolvers.default.acme.dnschallenge.provider=joker"
+      - "--certificatesresolvers.default.acme.email=mail@example.com"
+      - "--certificatesresolvers.default.acme.storage=/letsencrypt/acme.json"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.web.http.redirections.entrypoint.to=websecure"
+      - "--entrypoints.web.http.redirections.entrypoint.scheme=https"
+      - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
+      - "--entrypoints.websecure.address=:443"
+      - "--entrypoints.websecure.http.tls=true"
+      - "--entrypoints.websecure.http.tls.certResolver=letsencrypt"
+      # Creates a wildcard certificate, messages like 404 pages are returned encrypted by Treafik.
+      - "--entrypoints.websecure.http.tls.domains[0].main=example.com"
+      - "--entrypoints.websecure.http.tls.domains[0].sans=*.example.com" #
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      # See here for your dns provider variables: https://go-acme.github.io/lego/dns/
+      - JOKER_API_MODE=SVC
+      - JOKER_USERNAME=${SECRET_DNS_JOKER_USERNAME} # e.g. use an .env file for this secret
+      - JOKER_PASSWORD=${SECRET_DNS_JOKER_PASSWORD} # e.g. use an .env file for this secret
+
+  whoami:
+    image: containous/whoami
+    labels:
+      traefik.enable: true
+      traefik.http.routers.whoami.entrypoints: websecure
+      traefik.http.routers.whoami.rule: Host(`whoami.example.com`)"

--- a/ssl/auto-ssl/dns-challenge/docker-compose.yml
+++ b/ssl/auto-ssl/dns-challenge/docker-compose.yml
@@ -1,0 +1,32 @@
+version: '3'
+
+services:
+  traefik:
+    image: traefik:v2.2
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - ./letsencrypt/:/letsencrypt/
+    command:
+      - "--providers.docker"
+      - "--entrypoints.web.address=:80"
+      - "--entrypoints.webwecure.address=:443"
+      - "--certificatesresolvers.default.acme.dnschallenge=true"
+      # See here for your dnschallenge provider: https://go-acme.github.io/lego/dns/
+      - "--certificatesresolvers.default.acme.dnschallenge.provider=joker"
+      - "--certificatesresolvers.default.acme.email=mail@example.com"
+      - "--certificatesresolvers.default.acme.storage=/letsencrypt/acme.json"
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      # See here for your dns provider variables: https://go-acme.github.io/lego/dns/
+      - JOKER_API_MODE=SVC
+      - JOKER_USERNAME=${SECRET_DNS_JOKER_USERNAME} # e.g. use an .env file for this secret
+      - JOKER_PASSWORD=${SECRET_DNS_JOKER_PASSWORD} # e.g. use an .env file for this secret
+
+  whoami:
+    image: containous/whoami
+    labels:
+      traefik.enable: true
+      traefik.http.routers.whoami.entrypoints: websecure
+      traefik.http.routers.whoami.rule: Host(`whoami.example.com`)"


### PR DESCRIPTION
Hi,
here is a small contribution for **SSL using a DNS-Challange**.

Feel free to adapt the two compose files to fit your coding style.
Nice project for a quick start in Treafik :)

ps: After using the `entrypoints.websecure.http.tls.domains[0].sans=` function, clear the cache by deleting the `acme.json` file. After that HTTP error messages are unencrypted again.

Greetings
Patrick